### PR TITLE
Use association default label in Up and Down action links

### DIFF
--- a/lib/cocooned/helpers.rb
+++ b/lib/cocooned/helpers.rb
@@ -15,8 +15,11 @@ module Cocooned
   # The label of any action links can be given explicitly as helper's first argument
   # or as a block, just as you can do on ActionView's `link_to` or similar helpers.
   # Additionally, Cocooned helpers will lookup I18n translations for a default label
-  # based on the action name (`add`, `remove`, `up`, `down`) and the association name
-  # (only for `add` and `remove`).
+  # based on the action name (`add`, `remove`, `up`, `down`) and the association name.
+  #
+  # For `add` action links, the association name used is the same as passed as
+  # argument. On other action links, it is extracted from nested form's
+  # #object_name.
   #
   # You can declare default labels in your translation files with following keys:
   #

--- a/lib/cocooned/tags/down.rb
+++ b/lib/cocooned/tags/down.rb
@@ -3,6 +3,8 @@
 module Cocooned
   module Tags
     class Down < Base # :nodoc:
+      include Cocooned::TagsHelper::AssociationLabel
+
       protected
 
       def html_classes

--- a/lib/cocooned/tags/remove.rb
+++ b/lib/cocooned/tags/remove.rb
@@ -22,15 +22,6 @@ module Cocooned
         end
       end
 
-      # Extract association name from form's object_name.
-      # Ex: 'items' from 'list[items_attributes][0]'
-      def association
-        matches = form.object_name.scan(/\[([^\]]+)\]\[[^\]]+\]\z/).flatten
-        return matches.first.delete_suffix('_attributes') if matches.size.positive?
-
-        form.object.class.to_s.tableize
-      end
-
       def new_record?
         !!form.object.try(:new_record?)
       end

--- a/lib/cocooned/tags/up.rb
+++ b/lib/cocooned/tags/up.rb
@@ -3,6 +3,8 @@
 module Cocooned
   module Tags
     class Up < Base # :nodoc:
+      include Cocooned::TagsHelper::AssociationLabel
+
       protected
 
       def html_classes

--- a/lib/cocooned/tags_helper.rb
+++ b/lib/cocooned/tags_helper.rb
@@ -30,8 +30,13 @@ module Cocooned
         super + i18n_namespaces.collect { |ns| "#{ns}.#{association}.#{action}" }
       end
 
+      # Extract association name from form's object_name.
+      # Ex: 'items' from 'list[items_attributes][0]'
       def association
-        raise NotImplementedError, '#association must be defined in subclasses'
+        matches = form.object_name.scan(/\[([^\]]+)\]\[[^\]]+\]\z/).flatten
+        return matches.first.delete_suffix('_attributes') if matches.size.positive?
+
+        form.object.class.to_s.tableize
       end
     end
 

--- a/spec/support/tag.rb
+++ b/spec/support/tag.rb
@@ -2,11 +2,7 @@
 
 module TagHelper
   def html(*args, **options, &block)
-    tag_template = try(:template) || ActionView::Base.empty
-    tag_form = try(:form) || double
-    tag_association = try(:association)
-    tag = described_class.create(tag_template, *(args + [tag_form, tag_association].compact), **options, &block)
-
+    tag = described_class.create(template, *(args + [form, try(:association)].compact), **options, &block)
     Nokogiri::HTML(tag.render)
   end
 

--- a/spec/unit/cocooned/tags/base_spec.rb
+++ b/spec/unit/cocooned/tags/base_spec.rb
@@ -3,10 +3,10 @@
 require_relative './shared/tag'
 
 describe Cocooned::Tags::Base, :tag do
-  describe '.create' do
-    let(:template) { ActionView::Base.empty }
-    let(:form) { double }
+  let(:template) { ActionView::Base.empty }
+  let(:form) { double }
 
+  describe '.create' do
     it 'creates a new tag' do
       expect(described_class.create(template, form)).to be_an_instance_of(described_class)
     end

--- a/spec/unit/cocooned/tags/down_spec.rb
+++ b/spec/unit/cocooned/tags/down_spec.rb
@@ -3,7 +3,12 @@
 require_relative './shared/tag'
 
 describe Cocooned::Tags::Down, :tag do
+  let(:template) { ActionView::Base.empty }
+  let(:record) { Person.new }
+  let(:form) { ActionView::Helpers::FormBuilder.new('person[contacts_attributes][0]', record, template, {}) }
+
   it_behaves_like 'an action tag builder', :down
+  it_behaves_like 'an action tag builder with an association', :down, :contacts
 
   it 'has a default class' do
     expect(tag.attribute('class').value.split).to include('cocooned-move-down')

--- a/spec/unit/cocooned/tags/up_spec.rb
+++ b/spec/unit/cocooned/tags/up_spec.rb
@@ -3,7 +3,12 @@
 require_relative './shared/tag'
 
 describe Cocooned::Tags::Up, :tag do
+  let(:template) { ActionView::Base.empty }
+  let(:record) { Person.new }
+  let(:form) { ActionView::Helpers::FormBuilder.new('person[contacts_attributes][0]', record, template, {}) }
+
   it_behaves_like 'an action tag builder', :up
+  it_behaves_like 'an action tag builder with an association', :up, :contacts
 
   it 'has a default class' do
     expect(tag.attribute('class').value.split).to include('cocooned-move-up')


### PR DESCRIPTION
As `cocooned_move_item_up_link` and `cocooned_move_item_down_link` take the same form as `cocooned_remove_item_link` as parameter, we can use the same method to contextualize their default label by association name.