### PR TITLE
Prevent double initialization

### DIFF
--- a/lib/cocooned/association/renderer.rb
+++ b/lib/cocooned/association/renderer.rb
@@ -34,7 +34,7 @@ module Cocooned
       end
 
       def form_options
-        options.fetch(:form_options, {}).symbolize_keys.reverse_merge(child_index: "new_#{singular_association}")
+        options.fetch(:form_options, {}).symbolize_keys.reverse_merge(child_index: "new_#{association}")
       end
 
       def partial

--- a/lib/cocooned/deprecation.rb
+++ b/lib/cocooned/deprecation.rb
@@ -74,7 +74,7 @@ module Cocooned
 
         def association_options
           if options.key? :insertion_traversal
-            Deprecation['3.0'].warn 'Support for the :insertion8traversal will be removed in 3.0', caller_locations(3)
+            Deprecation['3.0'].warn 'Support for the :insertion_traversal will be removed in 3.0', caller_locations(3)
           end
 
           super

--- a/npm/__tests__/unit/cocooned/base.js
+++ b/npm/__tests__/unit/cocooned/base.js
@@ -23,6 +23,16 @@ describe('Base', () => {
     </div>
   `)
 
+  it('associates itself with the container', () => {
+    expect(given.container.dataset).toEqual(expect.objectContaining({ cocoonedUuid: expect.any(String) }))
+  })
+
+  describe('getInstance', () => {
+    it('finds an instance by its UUID', () => {
+      expect(Base.getInstance(given.container.dataset.cocoonedUuid)).toEqual(given.instance)
+    })
+  })
+
   describe('when created', () => {
     given('styles', () => given.container.firstElementChild)
 

--- a/npm/__tests__/unit/cocooned/plugins/reorderable/triggers.js
+++ b/npm/__tests__/unit/cocooned/plugins/reorderable/triggers.js
@@ -124,6 +124,28 @@ describe('Move', () => {
         })
 
         itBehavesLikeAMoveTrigger()
+
+        describe('when item is persisted', () => {
+          given('template', () => `
+            <div class="cocooned-item">
+              <a class="cocooned-move-up" href="#">Up</a>
+              <a class="cocooned-move-down" href="#">Down</a>
+              <input type="hidden" name="items[0][position]" />
+            </div>
+            <!-- Inserted by Rails-->
+            <input type="hidden" value="" name="items[0][id]" id="items_1_id" />
+          `)
+
+          it('moves item up', () => {
+            given.move.handle(clickEvent())
+
+            const items = getItems(given.container)
+            const item = given.moveTrigger.closest('.cocooned-item')
+            const index = Array.from(items).findIndex(i => i === item)
+
+            expect(index).toEqual(given.index - 1)
+          })
+        })
       })
     })
   })
@@ -153,6 +175,28 @@ describe('Move', () => {
         })
 
         itBehavesLikeAMoveTrigger()
+
+        describe('when item is persisted', () => {
+          given('template', () => `
+            <div class="cocooned-item">
+              <a class="cocooned-move-up" href="#">Up</a>
+              <a class="cocooned-move-down" href="#">Down</a>
+              <input type="hidden" name="items[0][position]" />
+            </div>
+            <!-- Inserted by Rails-->
+            <input type="hidden" value="" name="items[0][id]" id="items_1_id" />
+          `)
+
+          it('moves item down', () => {
+            given.move.handle(clickEvent())
+
+            const items = getItems(given.container)
+            const item = given.moveTrigger.closest('.cocooned-item')
+            const index = Array.from(items).findIndex(i => i === item)
+
+            expect(index).toEqual(given.index + 1)
+          })
+        })
       })
     })
   })

--- a/npm/index.js
+++ b/npm/index.js
@@ -5,6 +5,10 @@ import { cocoonSupportMixin } from './src/integrations/cocoon'
 
 class Cocooned extends reorderableMixin(limitMixin(cocoonSupportMixin(Base))) {
   static create (container, options = {}) {
+    if ('cocoonedUuid' in container.dataset) {
+      return Cocooned.getInstance(container.dataset.cocoonedUuid)
+    }
+
     const cocooned = new Cocooned(container, options)
     cocooned.start()
 

--- a/npm/src/cocooned/base.js
+++ b/npm/src/cocooned/base.js
@@ -8,7 +8,7 @@ function uuidv4() {
 }
 
 const scopedStyles = `
-  .cocooned-item { overflow: hidden; transition: opacity .45s ease-out, max-height .45s ease-out .45; }
+  .cocooned-item { overflow: hidden; transition: opacity .45s ease-out, max-height .45s ease-out; }
   .cocooned-item--visible { opacity: 1; max-height: 100%; }
   .cocooned-item--hidden { opacity: 0; max-height: 0%; }
 `

--- a/npm/src/cocooned/base.js
+++ b/npm/src/cocooned/base.js
@@ -149,7 +149,7 @@ class Base {
   __uuid
   _container
   __emitter
-  _options = { transitions: !(process?.env?.NODE_ENV === 'test') }
+  _options = { transitions: !(typeof process !== 'undefined' && process.env.NODE_ENV === 'test') }
 
   get _emitter () {
     if (typeof this.__emitter === 'undefined') {

--- a/npm/src/cocooned/base.js
+++ b/npm/src/cocooned/base.js
@@ -1,5 +1,12 @@
 import { Emitter } from './events/emitter'
 
+// Borrowed from <https://stackoverflow.com/a/2117523>
+function uuidv4() {
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+      (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
+}
+
 const scopedStyles = `
   .cocooned-item { overflow: hidden; transition: opacity .45s ease-out, max-height .45s ease-out .45; }
   .cocooned-item--visible { opacity: 1; max-height: 100%; }
@@ -45,6 +52,8 @@ function toggle (item, removedClass, addedClass, useTransitions, callback) {
   }
 }
 
+const instances = Object.create(null)
+
 class Base {
   static get defaultOptions () {
     return {}
@@ -63,8 +72,13 @@ class Base {
     }
   }
 
+  static getInstance(uuid) {
+    return instances[uuid]
+  }
+
   constructor (container, options) {
     this._container = container
+    this._uuid = uuidv4()
     this._options = this.constructor._normalizeOptions({
       ...this._options,
       ...this.constructor.defaultOptions,
@@ -82,6 +96,9 @@ class Base {
   }
 
   start () {
+    this.container.dataset.cocoonedUuid = this._uuid
+    instances[this._uuid] = this
+
     this.container.classList.add('cocooned-container')
     this.container.prepend(createScopedStyles(this.container, this.constructor.scopedStyles))
 
@@ -129,6 +146,7 @@ class Base {
     return options
   }
 
+  __uuid
   _container
   __emitter
   _options = { transitions: !(process?.env?.NODE_ENV === 'test') }

--- a/npm/src/cocooned/plugins/core/triggers/add/extractor.js
+++ b/npm/src/cocooned/plugins/core/triggers/add/extractor.js
@@ -31,7 +31,7 @@ class Extractor {
       return null
     }
 
-    const template = document.querySelector(`template[data-name=${this.#dataset.template}]`)
+    const template = document.querySelector(`template[data-name="${this.#dataset.template}"]`)
     if (template === null) {
       return null
     }

--- a/npm/src/cocooned/plugins/reorderable/triggers.js
+++ b/npm/src/cocooned/plugins/reorderable/triggers.js
@@ -19,25 +19,31 @@ class Move extends Trigger {
 
   /* Protected and private attributes and methods */
   get _pivotItem () {
-    if (this._sibling !== null && this._cocooned.contains(this._sibling)) {
-      return this._sibling
-    }
-    return null
-  }
-
-  get _sibling () {
-    throw new TypeError('_sibling() must be defined in subclasses')
+    throw new TypeError('_pivotItem() must be defined in subclasses')
   }
 
   _move () {
     throw new TypeError('_move() must be defined in subclasses')
   }
+
+  _findPivotItem(origin, method) {
+    let sibling = origin
+
+    do {
+      sibling = sibling[method]
+      if (sibling !== null && this._cocooned.contains(sibling)) {
+        break
+      }
+    } while (sibling !== null)
+
+    return sibling
+  }
 }
 
 class Up extends Move {
   /* Protected and private attributes and methods */
-  get _sibling () {
-    return this._item.previousElementSibling
+  get _pivotItem () {
+    return this._findPivotItem(this._item, 'previousElementSibling')
   }
 
   _move () {
@@ -47,8 +53,8 @@ class Up extends Move {
 
 class Down extends Move {
   /* Protected and private attributes and methods */
-  get _sibling () {
-    return this._item.nextElementSibling
+  get _pivotItem () {
+    return this._findPivotItem(this._item, 'nextElementSibling')
   }
 
   _move () {

--- a/npm/src/integrations/cocoon.js
+++ b/npm/src/integrations/cocoon.js
@@ -33,7 +33,7 @@ const findContainer = function (trigger) {
 }
 
 const cocoonAutoStart = function (jQuery) {
-  jQuery('.add_fields').map((_i, adder) => findContainer(adder)).each((_i, container) => Jquery(container).cocooned())
+  jQuery('.add_fields').map((_i, adder) => findContainer(adder)).each((_i, container) => jQuery(container).cocooned())
 }
 
 export {

--- a/spec/unit/cocooned/association/renderer_spec.rb
+++ b/spec/unit/cocooned/association/renderer_spec.rb
@@ -36,9 +36,9 @@ describe Cocooned::Association::Renderer do
       end
 
       it 'specifies a child_index based on association name' do
-        allow(form).to receive(method).with(any_args, hash_including(child_index: 'new_contact'))
+        allow(form).to receive(method).with(any_args, hash_including(child_index: 'new_contacts'))
         renderer.render
-        expect(form).to have_received(method).with(any_args, hash_including(child_index: 'new_contact'))
+        expect(form).to have_received(method).with(any_args, hash_including(child_index: 'new_contacts'))
       end
 
       context 'with form_options' do


### PR DESCRIPTION
Recent changes removed check on Cocooned instance creation to prevent multiple initialization for the same container, when auto-start and legacy Cocoon initializations detect the same containers for example.

This fix it and a couple other bugs.