### PR TITLE
Replace CSS animations with JavaScript Web Animation API

### DIFF
--- a/npm/__tests__/features/cocooned.js
+++ b/npm/__tests__/features/cocooned.js
@@ -72,31 +72,35 @@ describe('A basic Cocooned setup', () => {
       given('addLink', () => getAddLink(given.container))
       given('removeLink', () => getRemoveLink(given.container))
 
-      it('removes an item from the container', () => {
+      it('removes an item from the container', async () => {
         given.removeLink.dispatchEvent(clickEvent())
+        await new Promise(process.nextTick)
 
         expect(getItems(given.container).length).toEqual(0)
       })
 
-      it('removes only one item from the container', () => {
+      it('removes only one item from the container', async () => {
         given.addLink.dispatchEvent(clickEvent())
         given.removeLink.dispatchEvent(clickEvent())
+        await new Promise(process.nextTick)
 
         expect(getItems(given.container).length).toEqual(1)
       })
 
-      it('removes the correct item from the container', () => {
+      it('removes the correct item from the container', async () => {
         given.addLink.dispatchEvent(clickEvent())
         const inserted = Array.from(getItems(given.container)).pop()
         getRemoveLink(inserted).dispatchEvent(clickEvent())
+        await new Promise(process.nextTick)
 
         expect(getItems(given.container)).not.toContain(inserted)
       })
 
-      it('triggers a before-remove event', () => {
+      it('triggers a before-remove event', async () => {
         const listener = jest.fn()
         given.container.addEventListener('cocooned:before-remove', listener)
         given.removeLink.dispatchEvent(clickEvent())
+        await new Promise(process.nextTick)
 
         expect(listener).toHaveBeenCalled()
       })
@@ -112,7 +116,7 @@ describe('A basic Cocooned setup', () => {
       given('item', () => document.querySelector('.cocooned-item'))
 
       it('hides those item when instanced', () => {
-        expect(getItem(given.container).classList).toContain('cocooned-item--hidden')
+        expect(getItem(given.container).style?.display).toEqual('none')
       })
     })
   })

--- a/npm/__tests__/unit/cocooned/base.js
+++ b/npm/__tests__/unit/cocooned/base.js
@@ -1,11 +1,16 @@
 /* global given */
 
 import { Base } from '@notus.sh/cocooned/src/cocooned/base'
-import { jest } from '@jest/globals'
 import { faker } from '@cocooned/tests/support/faker'
 import { getItem } from '@cocooned/tests/support/helpers'
 
 describe('Base', () => {
+  describe('defaultOptions', () => {
+    it('detects animation support', () => {
+      expect(Base.defaultOptions).toEqual(expect.objectContaining({ animate: false }))
+    })
+  })
+
   beforeEach(() => {
     document.body.innerHTML = given.html
     given.instance.start()

--- a/npm/__tests__/unit/cocooned/base.js
+++ b/npm/__tests__/unit/cocooned/base.js
@@ -9,6 +9,14 @@ describe('Base', () => {
     it('detects animation support', () => {
       expect(Base.defaultOptions).toEqual(expect.objectContaining({ animate: false }))
     })
+
+    it('returns default animation options', () => {
+      expect(Base.defaultOptions).toEqual(expect.objectContaining({
+        animate: expect.any(Boolean),
+        animator: expect.any(Function),
+        duration: expect.any(Number),
+      }))
+    })
   })
 
   beforeEach(() => {

--- a/npm/__tests__/unit/cocooned/plugins/core/triggers/remove.js
+++ b/npm/__tests__/unit/cocooned/plugins/core/triggers/remove.js
@@ -40,10 +40,11 @@ describe('Remove', () => {
     })
 
     describe('an after-remove event', () => {
-      it('is triggered', () => {
+      it('is triggered', async () => {
         const listener = jest.fn()
         given.container.addEventListener('cocooned:after-remove', listener)
         given.remove.handle(clickEvent())
+        await new Promise(process.nextTick)
 
         expect(listener).toHaveBeenCalled()
       })
@@ -62,8 +63,10 @@ describe('Remove', () => {
 
   describe('handle', () => {
     describe('with a dynamic item', () => {
-      it('remove item from document', () => {
+      it('remove item from document', async () => {
         given.remove.handle(clickEvent())
+        await new Promise(process.nextTick)
+
         expect(getItems(given.container)).toHaveLength(0)
       })
 
@@ -80,23 +83,31 @@ describe('Remove', () => {
         </div>
       `)
 
-      it('does not remove item from document', () => {
+      it('does not remove item from document', async () => {
         given.remove.handle(clickEvent())
+        await new Promise(process.nextTick)
+
         expect(getItems(given.container)).toHaveLength(1)
       })
 
-      it('hides item', () => {
+      it('hides item', async () => {
         given.remove.handle(clickEvent())
-        expect(given.item.classList).toContain('cocooned-item--hidden')
+        await new Promise(process.nextTick)
+
+        expect(given.item.style?.display).toEqual('none')
       })
 
-      it('marks item for destruction', () => {
+      it('marks item for destruction', async () => {
         given.remove.handle(clickEvent())
+        await new Promise(process.nextTick)
+
         expect(given.item.querySelector('input').getAttribute('value')).toBeTruthy()
       })
 
-      it('removes required on inputs', () => {
+      it('removes required on inputs', async () => {
         given.remove.handle(clickEvent())
+        await new Promise(process.nextTick)
+
         expect(given.item.querySelector('input').getAttributeNames()).not.toContain('required')
       })
 

--- a/npm/__tests__/unit/cocooned/plugins/reorderable/triggers.js
+++ b/npm/__tests__/unit/cocooned/plugins/reorderable/triggers.js
@@ -77,10 +77,11 @@ describe('Move', () => {
     })
 
     describe('an after-move event', () => {
-      it('is triggered', () => {
+      it('is triggered', async () => {
         const listener = jest.fn()
         given.container.addEventListener('cocooned:after-move', listener)
         given.move.handle(clickEvent())
+        await new Promise(process.nextTick)
 
         expect(listener).toHaveBeenCalled()
       })
@@ -112,8 +113,9 @@ describe('Move', () => {
       describe('with a pivot item', () => {
         given('index', () => faker.datatype.number({ min: 1, max: given.count - 1 }))
 
-        it('moves item up', () => {
+        it('moves item up', async () => {
           given.move.handle(clickEvent())
+          await new Promise(process.nextTick)
 
           const items = getItems(given.container)
           const item = given.moveTrigger.closest('[data-cocooned-item]')
@@ -135,8 +137,9 @@ describe('Move', () => {
             <input type="hidden" value="" name="items[0][id]" id="items_1_id" />
           `)
 
-          it('moves item up', () => {
+          it('moves item up', async () => {
             given.move.handle(clickEvent())
+            await new Promise(process.nextTick)
 
             const items = getItems(given.container)
             const item = given.moveTrigger.closest('[data-cocooned-item]')
@@ -163,8 +166,9 @@ describe('Move', () => {
       describe('with a pivot item', () => {
         given('index', () => faker.datatype.number({ min: 0, max: given.count - 2 }))
 
-        it('moves item down', () => {
+        it('moves item down', async () => {
           given.move.handle(clickEvent())
+          await new Promise(process.nextTick)
 
           const items = getItems(given.container)
           const item = given.moveTrigger.closest('[data-cocooned-item]')
@@ -186,8 +190,9 @@ describe('Move', () => {
             <input type="hidden" value="" name="items[0][id]" id="items_1_id" />
           `)
 
-          it('moves item down', () => {
+          it('moves item down', async () => {
             given.move.handle(clickEvent())
+            await new Promise(process.nextTick)
 
             const items = getItems(given.container)
             const item = given.moveTrigger.closest('[data-cocooned-item]')

--- a/npm/src/cocooned/base.js
+++ b/npm/src/cocooned/base.js
@@ -25,7 +25,8 @@ const instances = Object.create(null)
 
 class Base {
   static get defaultOptions () {
-    return {}
+    const element = document.createElement('div')
+    return { animate: ('animate' in element && typeof element.animate == 'function') }
   }
 
   static get eventNamespaces () {
@@ -47,7 +48,6 @@ class Base {
     this._container = container
     this._uuid = uuidv4()
     this._options = this.constructor._normalizeOptions({
-      ...this._options,
       ...this.constructor.defaultOptions,
       ...('cocoonedOptions' in container.dataset ? JSON.parse(container.dataset.cocoonedOptions) : {}),
       ...(options || {})
@@ -108,7 +108,7 @@ class Base {
       return item
     }
 
-    if (!opts.animate || !('animate' in item && typeof item.animate == 'function')) {
+    if (!opts.animate) {
       return Promise.resolve(after())
     }
 
@@ -124,7 +124,7 @@ class Base {
     }
 
     const promise = Promise.resolve(before())
-    if (!opts.animate || !('animate' in item && typeof item.animate == 'function')) {
+    if (!opts.animate) {
       return promise
     }
 
@@ -137,10 +137,10 @@ class Base {
     return options
   }
 
-  __uuid
   _container
+  _options
+  __uuid
   __emitter
-  _options = { animate: !(typeof process !== 'undefined' && process.env.NODE_ENV === 'test') }
 
   get _emitter () {
     if (typeof this.__emitter === 'undefined') {

--- a/npm/src/cocooned/base.js
+++ b/npm/src/cocooned/base.js
@@ -112,8 +112,12 @@ class Base {
       return Promise.resolve(after())
     }
 
-    const keyframes = [{ height: `${item.scrollHeight}px`, opacity: 1 }, { height: 0, opacity: 0 }]
-    return item.animate(keyframes, { duration: 450, easing: 'ease-in-out' }).finished.then(() => after())
+    const keyframes = [
+      { height: `${item.scrollHeight}px`, opacity: 1 },
+      { height: `${item.scrollHeight}px`, opacity: 0 },
+      { height: 0, opacity: 0 }
+    ]
+    return item.animate(keyframes, { duration: 300, easing: 'ease-in-out' }).finished.then(() => after())
   }
 
   show (item, options) {
@@ -128,7 +132,11 @@ class Base {
       return promise
     }
 
-    const keyframes = [{ height: 0, opacity: 0 }, { height: `${item.dataset.scrollHeight}px`, opacity: 1 }]
+    const keyframes = [
+      { height: 0, opacity: 0 },
+      { height: `${item.dataset.scrollHeight}px`, opacity: 0 },
+      { height: `${item.dataset.scrollHeight}px`, opacity: 1 }
+    ]
     return item.animate(keyframes, { duration: 450, easing: 'ease-in-out' }).finished.then(() => item)
   }
 

--- a/npm/src/cocooned/plugins/core/triggers/remove.js
+++ b/npm/src/cocooned/plugins/core/triggers/remove.js
@@ -7,7 +7,7 @@ class Remove extends Trigger {
       return false
     }
 
-    this._hide(this._item, () => {
+    this._hide(this._item).then(() => {
       this._remove()
       this._notify('after-remove', event)
     })

--- a/npm/src/cocooned/plugins/reorderable/triggers.js
+++ b/npm/src/cocooned/plugins/reorderable/triggers.js
@@ -11,9 +11,9 @@ class Move extends Trigger {
       return false
     }
 
-    this._hide(this._item, () => {
+    this._hide(this._item).then(() => {
       this._move()
-      this._show(this._item, () => this._notify('after-move', event))
+      this._show(this._item).then(() => this._notify('after-move', event))
     })
   }
 
@@ -42,8 +42,14 @@ class Move extends Trigger {
 
 class Up extends Move {
   /* Protected and private attributes and methods */
+  #pivotItem
+
   get _pivotItem () {
-    return this._findPivotItem(this._item, 'previousElementSibling')
+    if (typeof this.#pivotItem === 'undefined') {
+      this.#pivotItem = this._findPivotItem(this._item, 'previousElementSibling')
+    }
+
+    return this.#pivotItem
   }
 
   _move () {
@@ -53,8 +59,14 @@ class Up extends Move {
 
 class Down extends Move {
   /* Protected and private attributes and methods */
+  #pivotItem
+
   get _pivotItem () {
-    return this._findPivotItem(this._item, 'nextElementSibling')
+    if (typeof this.#pivotItem === 'undefined') {
+      this.#pivotItem = this._findPivotItem(this._item, 'nextElementSibling')
+    }
+
+    return this.#pivotItem
   }
 
   _move () {


### PR DESCRIPTION
This fix issue #28. It removes unnecessary and deprecated scoped styles and use Web Animation API to build show / hide animations.

Cocooned gets 3 new options in this move:

- `animate`: to enable or disable animations. Auto-set from Web Animation API support detection
- `animator`: a function to build animations keyframes
- `duration`: animation duration, in milliseconds

The animation functions accepts the same options and get their defaults from the Cocooned instance.