### PR TITLE
Make cocooned wrappers support custom tag name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+* Add support for custom tag name to container helpers (#55, #56)  
+  `cocooned_container` and `cocooned_item` now support an optional tag name as their first argument (as `content_tag` do) when the default `<div/>` is not appropriate.  
+  **Warning:** This change is not supposed to break anything as helpers prototypes stays the same and no other positional argument where really expected before. However, depending on how you used these helpers with previous releases, you may encounter unexpected side effects.
+
 ### Changed
 
 * Update test matrix (#54)  

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ And your sub form as follow:
 + <% end %>
 ```
 
-The `cocooned_container` and `cocooned_item` helpers will set for you the HTML attributes the JavaScript part of Cocooned expect to find to hook on. They will forward any option supported by ActionView's `content_tag`.
+The `cocooned_container` and `cocooned_item` helpers will set for you the HTML attributes the JavaScript part of Cocooned expect to find to hook on. They will forward any option supported by ActionView's `content_tag` and accept a tag name as first argument if you don't want to use the default `<div>`.
 
 ### 3. Add a way to add a new item to the list
 

--- a/lib/cocooned/helpers/containers.rb
+++ b/lib/cocooned/helpers/containers.rb
@@ -31,10 +31,11 @@ module Cocooned
       # will be forwarded.
       def cocooned_container(*args, &block)
         options = args.extract_options!.dup
+        name = args.shift || :div
         defaults = cocooned_wrapper_defaults(options, %w[cocooned-container], :'cocooned-container')
         defaults[:data][:cocooned_options] = options.extract!(:limit, :reorderable).to_json
 
-        content_tag(:div, *args, **options.deep_merge(defaults), &block)
+        content_tag(name, *args, **options.deep_merge(defaults), &block)
       end
 
       # Wrap content with the expected markup for a Cocooned item.
@@ -54,9 +55,10 @@ module Cocooned
       # be forwarded.
       def cocooned_item(*args, &block)
         options = args.extract_options!.dup
+        name = args.shift || :div
         defaults = cocooned_wrapper_defaults(options, %w[cocooned-item nested-fields], :'cocooned-item')
 
-        content_tag(:div, *args, **options.deep_merge(defaults), &block)
+        content_tag(name, *args, **options.deep_merge(defaults), &block)
       end
 
       protected

--- a/spec/support/action_view.rb
+++ b/spec/support/action_view.rb
@@ -2,7 +2,7 @@
 
 module ActionViewHelper
   def container(string)
-    Nokogiri::HTML(string).at('div')
+    Nokogiri::HTML(string).at('body > *')
   end
 end
 

--- a/spec/unit/cocooned/helpers/containers_spec.rb
+++ b/spec/unit/cocooned/helpers/containers_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Cocooned::Helpers::Containers, :action_view do
   let(:template) { ActionView::Base.empty }
 
   shared_examples 'a container helper' do |class_name, attribute_name|
+    it 'use div as default tag' do
+      html = method.call { 'any' }
+      expect(container(html).name).to eq('div')
+    end
+
     it 'has a default class' do
       html = method.call { 'any' }
       expect(container(html).attribute('class').value.split).to include(class_name)
@@ -14,6 +19,11 @@ RSpec.describe Cocooned::Helpers::Containers, :action_view do
       expect(container(html).attributes.keys).to include(attribute_name)
     end
 
+    it 'supports custom tag tag' do
+      html = method.call(:span) { 'any' }
+      expect(container(html).name).to eq('span')
+    end
+
     it 'supports additional classes' do
       html = method.call(class: 'more') { 'any' }
       expect(container(html).attribute('class').value.split).to include(class_name, 'more')
@@ -22,6 +32,24 @@ RSpec.describe Cocooned::Helpers::Containers, :action_view do
     it 'supports additional data attributes' do
       html = method.call(data: { attribute: 'value' }) { 'any' }
       expect(container(html).attributes.keys).to include(attribute_name, 'data-attribute')
+    end
+
+    context 'with all kind of arguments' do
+      subject(:parsed) { container(html) }
+
+      let(:html) { method.call(:span, class: 'more', data: { attribute: 'value' }) { 'any' } }
+
+      it 'uses correct tag' do
+        expect(parsed.name).to eq('span')
+      end
+
+      it 'has correct classes' do
+        expect(parsed.attribute('class').value.split).to include(class_name, 'more')
+      end
+
+      it 'has correct data attributes' do
+        expect(parsed.attributes.keys).to include(attribute_name, 'data-attribute')
+      end
     end
   end
 


### PR DESCRIPTION
Add support for tag name as first argument on `concooned_container` and `cocooned_item` helpers, just as ActionView's `content_tag` do.

```ruby
cocooned_container # <div data-cocooned-container></div>
cocooned_container(:span) # <span data-cocooned-container></span>
```

This should fix #55.