### PR TITLE
Apply replacements to nested templates when building a new item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `cocooned_container` and `cocooned_item` now support an optional tag name as their first argument (as `content_tag` do) when the default `<div/>` is not appropriate.  
   **Warning:** This change is not supposed to break anything as helpers prototypes stays the same and no other positional argument where really expected before. However, depending on how you used these helpers with previous releases, you may encounter unexpected side effects.
 
+### Fixed
+
+* Replacements operated on a newly built item in some nested use cases (#52, #57)  
+  Replacements are now done recursively in nested templates if any exists. This should fix field naming in newly built items when multiple Cocooned instance are nested and correct naming of sub-items depends on generated names for their parent.
+
 ### Changed
 
 * Update test matrix (#54)  

--- a/npm/__tests__/unit/cocooned/plugins/core/triggers/add/builder.js
+++ b/npm/__tests__/unit/cocooned/plugins/core/triggers/add/builder.js
@@ -23,6 +23,21 @@ describe('Builder', () => {
       desc: 'both singular',
       template: '<input type="text" id="contacts_new_person_name" name="contacts[new_person][name]">',
       expected: (id) => `<input type="text" id="contacts_${id}_name" name="contacts[${id}][name]">`
+    },
+    {
+      desc: 'nested',
+      template: `
+        <input type="text" id="contacts_new_person_name" name="contacts[new_person][name]">
+        <template>
+          <input type="text" id="contacts_new_person_new_attribute" name="contacts[new_person][new_attribute]">
+        </template>
+      `,
+      expected: (id) => `
+        <input type="text" id="contacts_${id}_name" name="contacts[${id}][name]">
+        <template>
+          <input type="text" id="contacts_${id}_new_attribute" name="contacts[${id}][new_attribute]">
+        </template>
+      `
     }
   ]
 

--- a/npm/src/cocooned/plugins/core/triggers/add/builder.js
+++ b/npm/src/cocooned/plugins/core/triggers/add/builder.js
@@ -59,10 +59,7 @@ class Builder {
 
   build (id) {
     const node = this.#documentFragment.cloneNode(true)
-    this.#replacements.forEach(replacement => {
-      node.querySelectorAll(`*[${replacement.attribute}]`).forEach(node => replacement.apply(node, id))
-    })
-
+    this.#applyReplacements(node, id)
     return node
   }
 
@@ -70,6 +67,16 @@ class Builder {
   #association
   #documentFragment
   #replacements
+
+  #applyReplacements(node, id) {
+    this.#replacements.forEach(replacement => {
+      node.querySelectorAll(`*[${replacement.attribute}]`).forEach(node => replacement.apply(node, id))
+    })
+
+    node.querySelectorAll('template').forEach(template => {
+      this.#applyReplacements(template.content, id)
+    })
+  }
 }
 
 export {


### PR DESCRIPTION
This should improve Cocooned behaviors for both #53 and #52.

So far, replacements were only applied to DOM nodes in the (cloned) content of the item template before inserting it as a new item. This changes this to also apply replacements to the contents of nested templates.

This means when building deeply nested forms where items can be dynamically added at any level, a new item at the top level should be ready to receive sub-items with correct `name`, `for` and `id` attributes.