### PR TITLE
Improve documentation on complex nested forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add support for custom tag name to container helpers (#55, #56)  
   `cocooned_container` and `cocooned_item` now support an optional tag name as their first argument (as `content_tag` do) when the default `<div/>` is not appropriate.  
   **Warning:** This change is not supposed to break anything as helpers prototypes stays the same and no other positional argument where really expected before. However, depending on how you used these helpers with previous releases, you may encounter unexpected side effects.
+* Documentation about nested use cases and event initialization (#59)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ If you have a `has_one` association, then you (probably) need to set `force_non_
 
 See the [original merge request](https://github.com/nathanvda/cocoon/pull/247) for more details.
 
+#### Complex nested forms
+
+If you want to build complex forms with multiple levels of nesting, make sure you [initialize Cocooned event handlers correctly for dynamically added child items](https://github.com/notus-sh/cocooned/blob/main/npm/README.md#complex-nested-forms) or your form won't behave as you might expect.
+
 ## Plugins
 
 Cocooned comes with two built-in plugins:
@@ -306,10 +310,10 @@ Remember to add `:position` as a permitted parameter in your controller.
 
 Each helper provided by Cocooned with a name ending with `_link` has its `_button` equivalent, to generate a `<button type="button" />` instead of a `<a href="#" />`:
 
-- `cocooned_add_item_link` <=> `cocooned_add_item_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/master/lib/cocooned/helpers/tags/add.rb))
-- `cocooned_remove_item_link` <=> `cocooned_remove_item_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/master/lib/cocooned/helpers/tags/remove.rb))
-- `cocooned_move_item_up_link` <=> `cocooned_move_item_up_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/master/lib/cocooned/helpers/tags/up.rb))
-- `cocooned_move_item_down_link` <=> `cocooned_move_item_down_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/master/lib/cocooned/helpers/tags/down.rb))
+- `cocooned_add_item_link` <=> `cocooned_add_item_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/main/lib/cocooned/helpers/tags/add.rb))
+- `cocooned_remove_item_link` <=> `cocooned_remove_item_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/main/lib/cocooned/helpers/tags/remove.rb))
+- `cocooned_move_item_up_link` <=> `cocooned_move_item_up_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/main/lib/cocooned/helpers/tags/up.rb))
+- `cocooned_move_item_down_link` <=> `cocooned_move_item_down_button` ([Documentation](https://github.com/notus-sh/cocooned/blob/main/lib/cocooned/helpers/tags/down.rb))
 
 While all `_link` helpers accept and will politely forward any option supported by ActionView's `link_to`, `_button` helpers will do the same with options supported by ActionView's `button_tag`.
 
@@ -328,7 +332,7 @@ If no translation is found, the default label will be the humanized action name.
 
 ## Javascript
 
-For more documentation about the JavaScript bundled in the companion package, please refer to [its own documentation](https://github.com/notus-sh/cocooned/blob/master/npm/README.md).
+For more documentation about the JavaScript bundled in the companion package, please refer to [its own documentation](https://github.com/notus-sh/cocooned/blob/main/npm/README.md).
 
 ## Styling forms
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -4,7 +4,7 @@ This is a companion package for the [cocooned Ruby gem](https://rubygems.org/gem
 
 Cocooned makes it easier to handle nested forms in Rails.
 
-Cocooned is form builder-agnostic: it works with standard Rails (>= 6.0, < 7.1) form helpers, [Formtastic](https://github.com/justinfrench/formtastic) or [SimpleForm](https://github.com/plataformatec/simple_form).
+Cocooned is form builder-agnostic: it works with standard Rails (>= 6.0, < 7.2) form helpers, [Formtastic](https://github.com/justinfrench/formtastic) or [SimpleForm](https://github.com/plataformatec/simple_form).
 
 1. [Installation](#installation)
 2. [Import](#import), default, custom or with [jQuery integration](#jquery-integration)
@@ -95,7 +95,19 @@ const cocooned = Cocooned.create(document.querySelector('a selector to match con
 const cocooned = Cocooned.create(document.querySelector('a selector to match container'), { limit: 12 })
 ```
 
-Options can also be provided as a JSON string in a `data-cocooned-options` on your container HTML tag. This is the recommended way to pass options from Ruby-land.
+Options can also be provided as a JSON string in a `data-cocooned-options` on your container HTML tag. This is the recommended way to pass options from Ruby-land (and is bundled in the `coconned_container` helper provided by the [cocooned Ruby gem](https://rubygems.org/gems/cocooned)).
+
+### Complex nested forms
+
+Although they come with their own challenges, as building a comprehensive interface for your users or dealing with validations on multiple levels, in some complex use cases you have no choices but to build forms with multiple levels of sub-components you may want to manage with Cocooned.
+
+As Cocooned is commonly initialized on page load with `Cocooned.start()`, action triggers in dynamically added child items (to add grand-child items) or to manipulate grand-child items (to delete them or to move them up or down if you use the reorderable plugin) will not be handled at first.
+
+To handle them, you need to tell Cocooned to initialize their event handlers when a new item is added with:
+
+```javascript
+document.addEventListener('cocooned:after-insert', e => Cocooned.create(e.detail.node))
+```
 
 ### jQuery integration
 
@@ -135,7 +147,7 @@ Duration of animations, in milliseconds. Defaults to 450.
 
 A function returning animation keyframes, either an array of keyframe objects or a keyframe object whose properties are arrays of values to iterate over. See [Keyframe Formats documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats) for more details.
 
-For an example of the expected function behavior, [look at the default animator](https://github.com/notus-sh/cocooned/blob/master/npm/src/cocooned/base.js#L24)
+For an example of the expected function behavior, [look at the default animator](https://github.com/notus-sh/cocooned/blob/main/npm/src/cocooned/base.js#L24)
 
 ### Plugins options
 


### PR DESCRIPTION
As most of recent issues were about deeply nested use cases (See #52, #48 and #47), we need to add more documentation around these.

This add new sections to READMEs of both the main Ruby gem and the NPM companion package to better explain how child items should be initialized if they can contain grand-child items managed with Cocooned.