### PR TITLE
Restrict lookup for new item template to the closest item if exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+* Template lookup in nested use cases (#61)  
+  Template lookup used to be done on the whole HTML document so add triggers can be declared anywhere inside or outside a Cocooned container. In nested use cases, this could lead to incorrect template being used to build grand-child items when multiple child items had been built since the last form save. Lookup is now done first inside the closest Cocooned item if any to ensure the correct template will be used.
+
 ## Version 2.1.0 (2024-01-28)
 
 ### Added

--- a/npm/__tests__/unit/cocooned/plugins/core/triggers/add/extractor.js
+++ b/npm/__tests__/unit/cocooned/plugins/core/triggers/add/extractor.js
@@ -1,5 +1,6 @@
 /* global given */
 
+import { Base as Cocooned } from '@notus.sh/cocooned/src/cocooned/base'
 import { Extractor } from '@notus.sh/cocooned/src/cocooned/plugins/core/triggers/add/extractor'
 import { Builder } from '@notus.sh/cocooned/src/cocooned/plugins/core/triggers/add/builder'
 import { deprecator } from '@notus.sh/cocooned/src/cocooned/deprecation'
@@ -10,9 +11,11 @@ import { getAddLink } from '@cocooned/tests/support/helpers'
 describe('Extractor', () => {
   beforeEach(() => { document.body.innerHTML = given.html })
 
-  given('extractor', () => new Extractor(given.addTrigger))
+  given('extractor', () => new Extractor(given.addTrigger, new Cocooned(given.container)))
+  given('container', () => document.querySelector('[data-cocooned-container]'))
   given('addTrigger', () => getAddLink(document))
   given('html', () => `
+    <div data-cocooned-container></div>
     <a data-cocooned-trigger="add" href="#">Add</a>
   `)
 
@@ -26,6 +29,7 @@ describe('Extractor', () => {
     describe('with data-count', () => {
       given('count', () => faker.number.int({ min: 2, max: 5 }))
       given('html', () => `
+        <div data-cocooned-container></div>
         <a data-cocooned-trigger="add"
            data-count="${given.count}"
            href="#">Add</a>
@@ -39,6 +43,7 @@ describe('Extractor', () => {
     describe('with data-association-insertion-count', () => {
       given('count', () => faker.number.int({ min: 2, max: 5 }))
       given('html', () => `
+        <div data-cocooned-container></div>
         <a data-cocooned-trigger="add"
            data-association-insertion-count="${given.count}"
            href="#">Add</a>
@@ -52,6 +57,7 @@ describe('Extractor', () => {
     describe('with data-association and data-template', () => {
       given('template', () => '<p>Template content</p>')
       given('html', () => `
+        <div data-cocooned-container></div>
         <a data-cocooned-trigger="add"
            data-association="item"
            data-template="template"
@@ -71,11 +77,40 @@ describe('Extractor', () => {
         const builder = given.extractor.extract().builder
         expect(builder.build('').firstElementChild.outerHTML).toEqual(given.template)
       })
+
+      describe('when in a nested context', () => {
+        given('addTrigger', () => getAddLink(given.container))
+        given('html', () => `
+          <div data-cocooned-container>
+            <div data-cocooned-item>
+              <a data-cocooned-trigger="add"
+                 data-association="item"
+                 data-template="template" href="#">Add</a>
+              <template data-name="template">${given.template}</template>
+            </div>
+            <div data-cocooned-item>
+              <a data-cocooned-trigger="add"
+                 data-association="item"
+                 data-template="template"
+                 href="#">Add</a>
+              <template data-name="template">Not me</template>
+            </div>
+          </div>
+          <a data-cocooned-trigger="add" data-association="item" data-template="template" href="#">Add</a>
+          <template data-name="template">Neither me</template>
+        `)
+
+        it('returns a Builder instance for the appropriate template', () => {
+          const builder = given.extractor.extract().builder
+          expect(builder.build('').firstElementChild.outerHTML).toEqual(given.template)
+        })
+      })
     })
 
     describe('with data-association-insertion-method', () => {
       given('method', () => 'any')
       given('html', () => `
+        <div data-cocooned-container></div>
         <a data-cocooned-trigger="add"
            data-association-insertion-method="${given.method}"
            href="#">Add</a>
@@ -91,6 +126,7 @@ describe('Extractor', () => {
 
       describe('when missing', () => {
         given('html', () => `
+          <div data-cocooned-container></div>
           <div class="node">
             <a data-cocooned-trigger="add" href="#">Add</a>
           </div>
@@ -103,6 +139,7 @@ describe('Extractor', () => {
 
       describe('when "this"', () => {
         given('html', () => `
+          <div data-cocooned-container></div>
           <a data-cocooned-trigger="add"
              data-association-insertion-node="this"
              href="#">Add</a>
@@ -115,6 +152,7 @@ describe('Extractor', () => {
 
       describe('when expressed as a selector', () => {
         given('html', () => `
+          <div data-cocooned-container></div>
           <div class="node"></div>
           <a data-cocooned-trigger="add"
              data-association-insertion-node=".node"
@@ -131,6 +169,7 @@ describe('Extractor', () => {
 
           given('deprecator', () => deprecator('3.0'))
           given('html', () => `
+            <div data-cocooned-container></div>
             <div class="node"></div>
             <a data-cocooned-trigger="add"
                data-association-insertion-node=".node"

--- a/npm/src/cocooned/plugins/core/triggers/add.js
+++ b/npm/src/cocooned/plugins/core/triggers/add.js
@@ -10,7 +10,7 @@ function uniqueId () {
 
 class Add extends Trigger {
   static create (trigger, cocooned) {
-    const extractor = new Extractor(trigger)
+    const extractor = new Extractor(trigger, cocooned)
     return new Add(trigger, cocooned, extractor.extract())
   }
 

--- a/npm/src/cocooned/plugins/core/triggers/add/extractor.js
+++ b/npm/src/cocooned/plugins/core/triggers/add/extractor.js
@@ -2,8 +2,9 @@ import { Builder } from './builder.js'
 import { deprecator, Traverser } from '../../../../deprecation.js'
 
 class Extractor {
-  constructor (trigger) {
+  constructor (trigger, cocooned) {
     this.#trigger = trigger
+    this.#cocooned = cocooned
   }
 
   extract () {
@@ -20,6 +21,7 @@ class Extractor {
   }
 
   /* Protected and private attributes and methods */
+  #cocooned
   #trigger
 
   get #dataset () {
@@ -31,7 +33,8 @@ class Extractor {
       return null
     }
 
-    const template = document.querySelector(`template[data-name="${this.#dataset.template}"]`)
+    const find = node => node?.querySelector(`template[data-name="${this.#dataset.template}"]`)
+    const template = find(this.#cocooned.toItem(this.#trigger)) || find(document)
     if (template === null) {
       return null
     }


### PR DESCRIPTION
This should fix #61.

When a form uses Cocooned on multiple nested levels, the name data attribute of the template used to build new grand-child item does not change between child item (as all where built from the same template). If multiple child item are added to the form at the same time and each contains an add trigger to build new grand-child items, they will all share the same template name.

So far, lookup was done with `document.querySelector` but this will always return the first template with a matching name, the one of the first built child item. The options extractor will now look only inside the closest cocooned item to find the template and instantiate a builder with the correct template.

As a fallback, if no template is found, it will still look through the whole document so top-level Cocooned instance can still have their add triggers (and their associated template) anywhere.