### PR TITLE
Rails 7.2 compatibility

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3"]
-        gemfile: [dev/gemfiles/rails-6.1.x.gemfile, dev/gemfiles/rails-7.0.x.gemfile, Gemfile]
+        gemfile: [dev/gemfiles/rails-6.1.x.gemfile, dev/gemfiles/rails-7.0.x.gemfile, dev/gemfiles/rails-7.1.x.gemfile, Gemfile]
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+* Add support for Rails v7.2 and drop support for Rails < 6.1 (#70)
+
 ## Version 2.2.1 (2024-05-20)
 
 ## Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cocooned (2.2.1)
-      rails (>= 6.0, <= 7.2)
+      rails (>= 6.1, <= 8.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Cocooned makes it easier to handle nested forms in Rails.
 
-Cocooned is form builder-agnostic: it works with standard Rails (>= 6.0, < 7.2) form helpers, [Formtastic](https://github.com/justinfrench/formtastic) or [SimpleForm](https://github.com/plataformatec/simple_form).
+Cocooned is form builder-agnostic: it works with standard Rails (>= 6.1, < 8.0) form helpers, [Formtastic](https://github.com/justinfrench/formtastic) or [SimpleForm](https://github.com/plataformatec/simple_form).
 
 1. [Background](#some-background)
 2. [Installation](#installation)

--- a/cocooned.gemspec
+++ b/cocooned.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   end
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency 'rails', '>= 6.0', '<= 7.2'
+  spec.add_dependency 'rails', '>= 6.1', '<= 8.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/dev/gemfiles/rails-7.1.x.gemfile
+++ b/dev/gemfiles/rails-7.1.x.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '../..'
+
+group :development, :test do
+  gem 'psych', '< 4.0.0'
+  gem 'puma'
+  gem 'rails', '~> 7.1.0'
+  gem 'shakapacker', '~> 7.1.0'
+  gem 'sqlite3', '~> 1.4'
+
+  gem 'formtastic', '~> 5.0'
+  gem 'nokogiri'
+  gem 'rspec-rails', '~> 6.0'
+  gem 'simplecov', require: false
+  gem 'simple_form', '~> 5.1'
+end

--- a/dev/rubocop.yml
+++ b/dev/rubocop.yml
@@ -11,6 +11,3 @@ AllCops:
 Naming/FileName:
   Exclude:
     - 'dev/**/*.gemfile'
-
-Rails/CompactBlank:
-  Enabled: false # As long as we support Rails 6.0

--- a/lib/cocooned/helpers/containers.rb
+++ b/lib/cocooned/helpers/containers.rb
@@ -64,8 +64,7 @@ module Cocooned
       protected
 
       def cocooned_wrapper_defaults(options, additional_classes, mark)
-        # TODO: Replace with compact_blank when dropping support for Rails 6.0
-        classes = Array.wrap(options.delete(:class)).flat_map { |k| k.to_s.split }.reject(&:blank?)
+        classes = Array.wrap(options.delete(:class)).flat_map { |k| k.to_s.split }.compact_blank
 
         { class: (classes + additional_classes), data: { mark => true } }
       end

--- a/lib/cocooned/tags/add.rb
+++ b/lib/cocooned/tags/add.rb
@@ -7,7 +7,6 @@ module Cocooned
         protected
 
         def association_options
-          # TODO: Replace with compact_blank when dropping support for Rails 6.0
           {
             association: association,
             template: html_template_name,
@@ -15,7 +14,7 @@ module Cocooned
             association_insertion_node: options.delete(:insertion_node),
             association_insertion_method: options.delete(:insertion_method),
             association_insertion_traversal: options.delete(:insertion_traversal)
-          }.reject { |_, value| value.blank? }
+          }.compact_blank
         end
       end
 

--- a/lib/cocooned/tags/base.rb
+++ b/lib/cocooned/tags/base.rb
@@ -47,14 +47,12 @@ module Cocooned
         @html_options ||= begin
           options[:class] = html_classes
           options[:data] = html_data
-          # TODO: Replace with compact_blank when dropping support for Rails 6.0
-          options.reject { |_, value| value.blank? }
+          options.compact_blank
         end
       end
 
       def html_classes
-        # TODO: Replace with compact_blank when dropping support for Rails 6.0
-        Array.wrap(options.delete(:class)).flat_map { |k| k.to_s.split }.reject(&:blank?)
+        Array.wrap(options.delete(:class)).flat_map { |k| k.to_s.split }.compact_blank
       end
     end
   end

--- a/npm/README.md
+++ b/npm/README.md
@@ -4,7 +4,7 @@ This is a companion package for the [cocooned Ruby gem](https://rubygems.org/gem
 
 Cocooned makes it easier to handle nested forms in Rails.
 
-Cocooned is form builder-agnostic: it works with standard Rails (>= 6.0, < 7.2) form helpers, [Formtastic](https://github.com/justinfrench/formtastic) or [SimpleForm](https://github.com/plataformatec/simple_form).
+Cocooned is form builder-agnostic: it works with standard Rails (>= 6.1, < 8.0) form helpers, [Formtastic](https://github.com/justinfrench/formtastic) or [SimpleForm](https://github.com/plataformatec/simple_form).
 
 1. [Installation](#installation)
 2. [Import](#import), default, custom or with [jQuery integration](#jquery-integration)


### PR DESCRIPTION
Add support for Rails 7.2 and drop support for Rails v6.0, since it reached EOL on June 1st, 2023.