### PR TITLE
Reintroduce Ruby 2.7 in test matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
         gemfile: [
           dev/gemfiles/rails-7.0.x.gemfile,
           dev/gemfiles/rails-7.1.x.gemfile,
@@ -18,6 +18,8 @@ jobs:
         ]
         exclude:
           # Exclude rubies < 3.1 for ActiveModel >= 7.2
+          - ruby: "2.7"
+            gemfile: Gemfile
           - ruby: "3.0"
             gemfile: Gemfile
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps


### PR DESCRIPTION
So tested rubies will be the same as the ones Rails officially supports.