### PR TITLE
Upgrade to rspec-rails ~> 8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development, :test do
 
   gem 'formtastic', '~> 5.0'
   gem 'nokogiri'
-  gem 'rspec-rails', '~> 7.0'
+  gem 'rspec-rails', '~> 8.0'
   gem 'simple_form', '~> 5.1'
 
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,10 +214,10 @@ GEM
     rspec-mocks (3.13.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (7.1.1)
-      actionpack (>= 7.0)
-      activesupport (>= 7.0)
-      railties (>= 7.0)
+    rspec-rails (8.0.2)
+      actionpack (>= 7.2)
+      activesupport (>= 7.2)
+      railties (>= 7.2)
       rspec-core (~> 3.13)
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
@@ -309,7 +309,7 @@ DEPENDENCIES
   rails
   rake (~> 13.0)
   rspec (~> 3.11)
-  rspec-rails (~> 7.0)
+  rspec-rails (~> 8.0)
   rubocop
   rubocop-performance
   rubocop-rails
@@ -398,7 +398,7 @@ CHECKSUMS
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.6) sha256=78b137ae5e91c5072bf81d40d78189aa911e965a81adc245e2d8d9ba624d9b4e
-  rspec-rails (7.1.1) sha256=e15dccabed211e2fd92f21330c819adcbeb1591c1d66c580d8f2d8288557e331
+  rspec-rails (8.0.2) sha256=113139a53f5d068d4f48d1c29ad5f982013ed9b0daa69d7f7b266eda5d433ace
   rspec-support (3.13.6) sha256=2e8de3702427eab064c9352fe74488cc12a1bfae887ad8b91cba480ec9f8afb2
   rubocop (1.81.6) sha256=a7095eca1b79bbbe7d81c74c11ed2c532faa868bd9d31c2f12b7be7fbfbfef42
   rubocop-ast (1.47.1) sha256=592682017855408b046a8190689490763aecea175238232b1b526826349d01ae

--- a/dev/gemfiles/rails-7.2.x.gemfile
+++ b/dev/gemfiles/rails-7.2.x.gemfile
@@ -5,15 +5,12 @@ source 'http://rubygems.org'
 gemspec path: '../..'
 
 group :development, :test do
-  gem 'psych', '< 4.0.0'
   gem 'puma'
   gem 'rails', '~> 7.2.0'
-  gem 'shakapacker', '~> 7.1.0'
   gem 'sqlite3', '~> 1.4'
 
   gem 'formtastic', '~> 5.0'
-  gem 'nokogiri'
-  gem 'rspec-rails', '~> 6.0'
+  gem 'rspec-rails', '~> 8.0'
   gem 'simplecov', require: false
   gem 'simple_form', '~> 5.1'
 end

--- a/dev/gemfiles/rails-8.0.x.gemfile
+++ b/dev/gemfiles/rails-8.0.x.gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem 'sqlite3', '~> 2.0'
 
   gem 'formtastic', '~> 5.0'
-  gem 'rspec-rails', '~> 7.0'
+  gem 'rspec-rails', '~> 8.0'
   gem 'simplecov', require: false
   gem 'simple_form', '~> 5.3'
 end


### PR DESCRIPTION
Now Rails 7.1 is unsupported, upgrade `rspec-rails` to the latest compatible release.