### PR TITLE
Postpone all deprecations to Cocooned 4.0

### DIFF
--- a/lib/cocooned/deprecation.rb
+++ b/lib/cocooned/deprecation.rb
@@ -26,14 +26,14 @@ module Cocooned
           cocooned_add_item_link(...)
         end
         deprecate link_to_add_association: 'Use :cocooned_add_link instead',
-                  deprecator: Deprecation['3.0']
+                  deprecator: Deprecation['4.0']
 
         # @deprecated: Please use {#cocooned_remove_item_link} instead
         def link_to_remove_association(...)
           cocooned_remove_item_link(...)
         end
         deprecate link_to_remove_association: 'Use :cocooned_remove_item_link instead',
-                  deprecator: Deprecation['3.0']
+                  deprecator: Deprecation['4.0']
       end
     end
 
@@ -44,7 +44,7 @@ module Cocooned
         def i18n_namespaces
           return super unless I18n.exists?(:cocoon)
 
-          Deprecation['3.0'].warn 'Support for the :cocoon i18n namespace will be removed in 3.0', caller_locations(3)
+          Deprecation['4.0'].warn 'Support for the :cocoon i18n namespace will be removed in 4.0', caller_locations(3)
           super + %w[cocoon]
         end
       end
@@ -57,7 +57,7 @@ module Cocooned
         def html_data
           return super unless data_keys.size.positive?
 
-          Deprecation['3.0'].warn 'Compatibility with options named data-* will be removed in 3.0', caller_locations(3)
+          Deprecation['4.0'].warn 'Compatibility with options named data-* will be removed in 4.0', caller_locations(3)
           html_data_normalize super.merge(data_options)
         end
 
@@ -78,7 +78,7 @@ module Cocooned
 
         def association_options
           if options.key? :insertion_traversal
-            Deprecation['3.0'].warn 'Support for the :insertion_traversal will be removed in 3.0', caller_locations(3)
+            Deprecation['4.0'].warn 'Support for the :insertion_traversal will be removed in 4.0', caller_locations(3)
           end
 
           super
@@ -91,7 +91,7 @@ module Cocooned
         def renderer_options
           return super unless options.key?(:render_options)
 
-          Deprecation['3.0'].warn 'Support for :render_options will be removed in 3.0', caller_locations(3)
+          Deprecation['4.0'].warn 'Support for :render_options will be removed in 4.0', caller_locations(3)
           legacy_options = options.delete(:render_options)
 
           super.tap do |opts|

--- a/npm/__tests__/unit/cocooned/deprecation.js
+++ b/npm/__tests__/unit/cocooned/deprecation.js
@@ -6,19 +6,19 @@ import { faker } from '@cocooned/tests/support/faker'
 
 describe('deprecator', () => {
   it('returns a configured Deprecator', () => {
-    const built = deprecator('3.0')
+    const built = deprecator('4.0')
 
-    expect(built.version).toEqual('3.0')
+    expect(built.version).toEqual('4.0')
     expect(built.package).toEqual('Cocooned')
     expect(built.logger).toBe(console)
   })
 
   it('returns always the same Deprecator for the same package name and version', () => {
-    expect(deprecator('3.0')).toBe(deprecator('3.0'))
+    expect(deprecator('4.0')).toBe(deprecator('4.0'))
   })
 
   it('returns different Deprecators for different package name or version', () => {
-    expect(deprecator('3.0')).not.toBe(deprecator('3.0', 'Package'))
+    expect(deprecator('4.0')).not.toBe(deprecator('4.0', 'Package'))
   })
 })
 

--- a/npm/__tests__/unit/cocooned/plugins/core/triggers/add/extractor.js
+++ b/npm/__tests__/unit/cocooned/plugins/core/triggers/add/extractor.js
@@ -170,7 +170,7 @@ describe('Extractor', () => {
           beforeEach(() => { given.deprecator.logger = { warn: jest.fn() } })
           afterEach(() => jest.restoreAllMocks())
 
-          given('deprecator', () => deprecator('3.0'))
+          given('deprecator', () => deprecator('4.0'))
           given('html', () => `
             <div data-cocooned-container></div>
             <div class="node"></div>

--- a/npm/cocooned.js
+++ b/npm/cocooned.js
@@ -1,7 +1,7 @@
 import Cocooned from './jquery.js'
 import { deprecator } from './src/cocooned/deprecation.js'
 
-deprecator('3.0').warn(
+deprecator('4.0').warn(
   'Loading @notus.sh/cocooned/cocooned is deprecated',
   '@notus.sh/cocooned/jquery, @notus.sh/cocooned or `@notus.sh/cocooned/src/cocooned/cocooned`'
 )

--- a/npm/src/cocooned/base.js
+++ b/npm/src/cocooned/base.js
@@ -91,7 +91,7 @@ class Base {
 
   start () {
     if (!('cocoonedContainer' in this.container.dataset)) {
-      deprecator('3.0').warn(
+      deprecator('4.0').warn(
         'CSS classes based detection is deprecated',
         'cocooned_container Rails helper to declare containers'
       )

--- a/npm/src/cocooned/plugins/core/triggers/add/extractor.js
+++ b/npm/src/cocooned/plugins/core/triggers/add/extractor.js
@@ -79,7 +79,7 @@ class Extractor {
       return this.#trigger.ownerDocument.querySelector(node)
     }
 
-    deprecator('3.0').warn('associationInsertionTraversal is deprecated')
+    deprecator('4.0').warn('associationInsertionTraversal is deprecated')
     const traverser = new Traverser(this.#trigger, this.#dataset.associationInsertionTraversal)
 
     return traverser.resolve(node)

--- a/spec/support/deprecation.rb
+++ b/spec/support/deprecation.rb
@@ -16,7 +16,7 @@ RSpec.configure do |config|
   # Disable deprecation warnings in all tests
   # Due to use of specific per-future-release deprecator, we have to silence each of them.
   config.before(:all) do
-    Cocooned::Deprecation['3.0'].behavior = :silence
+    Cocooned::Deprecation['4.0'].behavior = :silence
   end
 
   # Include deprecation helpers in tests tagged with `deprecation: 'version'`.

--- a/spec/unit/cocooned/helpers/containers_spec.rb
+++ b/spec/unit/cocooned/helpers/containers_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Cocooned::Helpers::Containers, :action_view do
 
     it_behaves_like 'a container helper', 'cocooned-item', 'data-cocooned-item'
 
-    it 'has a legacy class', deprecation: '3.0' do
+    it 'has a legacy class', deprecation: '4.0' do
       html = method.call { 'any' }
       expect(container(html).attribute('class').value.split).to include('nested-fields')
     end

--- a/spec/unit/cocooned/helpers/tags_spec.rb
+++ b/spec/unit/cocooned/helpers/tags_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Cocooned::Helpers::Tags do
     it_behaves_like 'a tag helper to move down', :button
   end
 
-  context 'with deprecated methods', deprecation: '3.0' do
+  context 'with deprecated methods', deprecation: '4.0' do
     describe '#link_to_add_association' do
       it 'is an alias to #cocooned_add_item_link' do
         allow(template).to receive(:cocooned_add_item_link)
@@ -155,7 +155,7 @@ RSpec.describe Cocooned::Helpers::Tags do
       end
 
       it 'warns about deprecation' do
-        with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+        with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
           expect do
             template.link_to_add_association('label', form, association)
           end.to raise_error(ActiveSupport::DeprecationException)
@@ -172,7 +172,7 @@ RSpec.describe Cocooned::Helpers::Tags do
       end
 
       it 'warns about deprecation' do
-        with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+        with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
           expect do
             template.link_to_remove_association('label', form)
           end.to raise_error(ActiveSupport::DeprecationException)

--- a/spec/unit/cocooned/railtie_spec.rb
+++ b/spec/unit/cocooned/railtie_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Cocooned::Railtie do
   it { is_expected.to respond_to(:cocooned_move_item_up_link) }
   it { is_expected.to respond_to(:cocooned_move_item_down_link) }
 
-  context 'with deprecated methods', deprecation: '3.0' do
+  context 'with deprecated methods', deprecation: '4.0' do
     it { is_expected.to respond_to(:link_to_add_association) }
     it { is_expected.to respond_to(:link_to_remove_association) }
   end

--- a/spec/unit/cocooned/tags/add_spec.rb
+++ b/spec/unit/cocooned/tags/add_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Cocooned::Tags::Add do
       expect(tag.attribute('class').value.split).to include('cocooned-add')
     end
 
-    it 'has a compatibility class with the original Cocoon', deprecation: '3.0' do
+    it 'has a compatibility class with the original Cocoon', deprecation: '4.0' do
       expect(tag.attribute('class').value.split).to include('add_fields')
     end
 
@@ -103,8 +103,8 @@ RSpec.describe Cocooned::Tags::Add do
         expect(attr.value).to eq('parent')
       end
 
-      it 'warns about deprecation', deprecation: '3.0' do
-        with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+      it 'warns about deprecation', deprecation: '4.0' do
+        with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
           expect { tag(insertion_traversal: :parent) }.to raise_error(ActiveSupport::DeprecationException)
         end
       end
@@ -194,7 +194,7 @@ RSpec.describe Cocooned::Tags::Add do
     it_behaves_like 'a renderer options forwarder', :partial, 'person'
     it_behaves_like 'a renderer options forwarder', :locals, { a: 1 }
 
-    context 'with render options', deprecation: '3.0' do
+    context 'with render options', deprecation: '4.0' do
       context 'with locals' do
         let(:render_options) { { locals: { a: 1 } } }
 
@@ -206,7 +206,7 @@ RSpec.describe Cocooned::Tags::Add do
         end
 
         it 'warns about deprecation' do
-          with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+          with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
             expect { tag(render_options: render_options) }.to raise_error(ActiveSupport::DeprecationException)
           end
         end
@@ -223,7 +223,7 @@ RSpec.describe Cocooned::Tags::Add do
         end
 
         it 'warns about deprecation' do
-          with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+          with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
             expect { tag(render_options: render_options) }.to raise_error(ActiveSupport::DeprecationException)
           end
         end

--- a/spec/unit/cocooned/tags/remove_spec.rb
+++ b/spec/unit/cocooned/tags/remove_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Cocooned::Tags::Remove do
       expect(tag.attribute('class').value.split).to include('cocooned-remove')
     end
 
-    it 'has a compatibility class with the original Cocoon', deprecation: '3.0' do
+    it 'has a compatibility class with the original Cocoon', deprecation: '4.0' do
       expect(tag.attribute('class').value.split).to include('remove_fields')
     end
 

--- a/spec/unit/cocooned/tags/shared/association_tag.rb
+++ b/spec/unit/cocooned/tags/shared/association_tag.rb
@@ -9,14 +9,14 @@ RSpec.shared_examples 'an action tag builder with an association', :tag do |acti
       expect(tag.text).to eq('Translated')
     end
 
-    it 'does not warn about deprecation', deprecation: '3.0' do
-      with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+    it 'does not warn about deprecation', deprecation: '4.0' do
+      with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
         expect { tag.text }.not_to raise_error
       end
     end
   end
 
-  context 'with translations available in the :cocooned namespace', deprecation: '3.0' do
+  context 'with translations available in the :cocooned namespace', deprecation: '4.0' do
     before { I18n.backend.store_translations(I18n.locale, cocoon: { association => { action => 'Translated' } }) }
     after { I18n.reload! }
 
@@ -25,7 +25,7 @@ RSpec.shared_examples 'an action tag builder with an association', :tag do |acti
     end
 
     it 'warns about deprecation' do
-      with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+      with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
         expect { tag.text }.to raise_error(ActiveSupport::DeprecationException)
       end
     end

--- a/spec/unit/cocooned/tags/shared/tag.rb
+++ b/spec/unit/cocooned/tags/shared/tag.rb
@@ -22,14 +22,14 @@ RSpec.shared_examples 'an action tag builder', :tag do |action|
       expect(tag.text).to eq('Translated')
     end
 
-    it 'does not warn about deprecation', deprecation: '3.0' do
-      with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+    it 'does not warn about deprecation', deprecation: '4.0' do
+      with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
         expect { tag.text }.not_to raise_error
       end
     end
   end
 
-  context 'with translations available in the :cocooned namespace', deprecation: '3.0' do
+  context 'with translations available in the :cocooned namespace', deprecation: '4.0' do
     before { I18n.backend.store_translations(I18n.locale, cocoon: { defaults: { action => 'Translated' } }) }
     after { I18n.reload! }
 
@@ -38,7 +38,7 @@ RSpec.shared_examples 'an action tag builder', :tag do |action|
     end
 
     it 'warns about deprecation' do
-      with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+      with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
         expect { tag.text }.to raise_error(ActiveSupport::DeprecationException)
       end
     end
@@ -68,13 +68,13 @@ RSpec.shared_examples 'an action tag builder', :tag do |action|
       expect(tag(data: { attr: 'any' }).attribute('data-attr')).not_to be_nil
     end
 
-    context 'when using older data-* options', deprecation: '3.0' do
+    context 'when using older data-* options', deprecation: '4.0' do
       it 'supports them as data-attributes' do
         expect(tag('data-attr': 'any').attribute('data-attr')).not_to be_nil
       end
 
       it 'warns about deprecation' do
-        with_deprecation_as_exception(Cocooned::Deprecation['3.0']) do
+        with_deprecation_as_exception(Cocooned::Deprecation['4.0']) do
           expect { tag('data-attr': 'any') }.to raise_error(ActiveSupport::DeprecationException)
         end
       end


### PR DESCRIPTION
With the introduction of some breaking changes in the next release, a bump of the major version number seems to be the correct move considering semantic versioning semantic. To not introduce too many breaking changes in a single release, removal of the long-time deprecated Cocoon and Cocooned v1 compatibility may better be postponed to the next major release.